### PR TITLE
fix($breadcrumb): use $stateParams in case of unhierarchical states.

### DIFF
--- a/src/angular-breadcrumb.js
+++ b/src/angular-breadcrumb.js
@@ -18,7 +18,7 @@ function $Breadcrumb() {
         angular.extend($$options, options);
     };
 
-    this.$get = ['$state', '$rootScope', function($state, $rootScope) {
+    this.$get = ['$state', '$stateParams', '$rootScope', function($state, $stateParams, $rootScope) {
 
         var $lastViewScope = $rootScope;
 
@@ -57,7 +57,7 @@ function $Breadcrumb() {
             }
 
             if(!state.abstract && !$$isStateDataProperty(state, 'ncyBreadcrumbSkip')) {
-                state.ncyBreadcrumbLink = $state.href(state.name);
+                state.ncyBreadcrumbLink = $state.href(state.name, $stateParams || {});
                 chain.unshift(state);
             }
         };


### PR DESCRIPTION
Hi @ncuillery, 
Thanks for your hard working. You have done a great job here. 
I added one bug fix for parent URL. Here is my case: 

```
angular.module('app', []).config(function($stateProvider) {
  $stateProvider.state('communities', {
    url: '/',
    controller: 'CommunitiesCtrl',
    templateUrl: 'app/communities/index.html',
    data: {
      ncyBreadcrumbLabel: 'Home'
    }

  }).state('communities-list', {
    url: '/:community',
    controller: 'CommunitiesListCtrl',
    templateUrl: 'app/communities/list/index.html',
    data: {
      ncyBreadcrumbLabel: '{{breadscrumb.name}}',
      ncyBreadcrumbParent: 'communities'
    }

  }).state('communities-detail', {
    url: '/:community/:id',
    controller: 'CommunitesDetailCtrl',
    templateUrl: 'app/communities/detail/index.html',
    data: {
      ncyBreadcrumbLabel: 'post',
      ncyBreadcrumbParent: 'communities-list'
    }
  });
})
```

Imagine that I have 3 states, look like these: 
`communities` => `http://localhost`
`communities-list` => `http://localhost/cute-girls` or `http://localhost/cute-boys`...
`communities-detail` => `http://localhost/cute-girls/01`...

Because `communities-list` state need a param `:community`, so that when I am in `app-communities-detail` state (for example: `http://localhost/cute-girls/01`), I can not go back to previous state which is `http://localhost/cute-girls`.

Checkout my PR. I fixed that by adding `$stateParams` when you build `ncyBreadcrumbLink`.

Thanks!
