### PR TITLE
Added support for meteor packaging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var LIVERELOAD_PORT = 35729;
-var lrSnippet = require('connect-livereload')({ port: LIVERELOAD_PORT });
+var lrSnippet = require('connect-livereload')({
+  port: LIVERELOAD_PORT
+});
 var mountFolder = function (connect, dir) {
   return connect.static(require('path').resolve(dir));
 };
@@ -174,7 +176,18 @@ module.exports = function (grunt) {
     },
     clean: {
       release: ["sample/*.zip"],
-      test: ["testDependencies/*"]
+      test: ["testDependencies/*"],
+      meteor: ['.build.*', 'versions.json']
+    },
+    exec: {
+      'meteor-init': {
+        command: [
+          'type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }'
+        ].join(';')
+      },
+      'meteor-publish': {
+        command: 'meteor publish'
+      }
     },
     compress: {
       release: {
@@ -182,7 +195,11 @@ module.exports = function (grunt) {
           archive: 'sample/<%= pkg.name %>-<%= pkg.version %>.zip'
         },
         files: [
-          {expand: true, cwd: 'release/', src: ['*.js']}
+          {
+            expand: true,
+            cwd: 'release/',
+            src: ['*.js']
+          }
         ]
       }
     },
@@ -226,6 +243,9 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-open');
   grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-text-replace');
+  grunt.loadNpmTasks('grunt-exec');
+
+  grunt.registerTask('meteor-publish', ['exec:meteor-init', 'exec:meteor-publish']);
 
   grunt.registerTask('test', ['jshint', 'testMin', 'test1dot2']);
   grunt.registerTask('testMin', ['clean:test', 'shell:testMinimal', 'karma']);
@@ -235,8 +255,8 @@ module.exports = function (grunt) {
 
   grunt.registerTask('sample', ['concat:dev', 'copy:asset', 'copy:img', 'connect:livereload', 'open', 'watch']);
 
-  grunt.registerTask('release-prepare', 'Update all files for a release', function(target) {
-    if(!target) {
+  grunt.registerTask('release-prepare', 'Update all files for a release', function (target) {
+    if (!target) {
       target = 'patch';
     }
     grunt.task.run(

--- a/package.js
+++ b/package.js
@@ -1,0 +1,13 @@
+Package.describe({
+  name: 'ncuillery:angular-breadcrumb',
+  version: '0.3.3',
+  summary: 'angular-breadcrumb for meteor!',
+  git: 'https://github.com/ncuillery/angular-breadcrumb',
+  documentation: 'README.md'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom('METEOR@0.9.0.1');
+  api.use('urigo:angular@0.8.4', 'client');
+  api.addFiles('dist/angular-breadcrumb.js', 'client');
+});

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "grunt-text-replace": "^0.3.12",
     "karma": "~0.10.2",
     "karma-coverage": "~0.1.0",
-    "karma-story-reporter": "~0.2.2"
+    "karma-story-reporter": "~0.2.2",
+	"grunt-exec": "^0.4.6",
+    "spacejam": "^1.1.1"
   },
   "keywords": ["angular", "breadcrumb"]
 }


### PR DESCRIPTION
Hi @ncuillery,

I'm a package maintainer for Meteor.js, a popular full-stack JavaScript framework.
I'm also a developer on angular-meteor, a library that let's you work with AngularJS on top of Meteor.

A lot of our users use angular-breadcrumb and it right now there is a separate package and Github repo that simply manually copies your distribution and publish it to Meteor.
This PR will allow you to directly publish updated versions of angular-breadcrumb as they become available. All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer to the "ncuillery" organization there.

I've already published the current version of the package on Atmosphere (Meteor's package directory). When you release new versions of angular-breadcrumb, you'll be able to publish them to Atmosphere by running make meteor.

Thanks & best regards,
Dotan