### PR TITLE
add ncyBreadcrumbGetLink function to step object

### DIFF
--- a/src/angular-breadcrumb.js
+++ b/src/angular-breadcrumb.js
@@ -52,7 +52,6 @@ function $Breadcrumb() {
         // Add the state in the chain if not already in and if not abstract
         var $$addStateInChain = function(chain, stateRef) {
             var conf,
-                parentParams,
                 ref = parseStateRef(stateRef),
                 force = false,
                 skip = false;
@@ -70,11 +69,16 @@ function $Breadcrumb() {
                 if(conf.ncyBreadcrumb.skip){ skip = true; }
             }
             if((!conf.abstract || $$options.includeAbstract || force) && !skip) {
-                if(ref.paramExpr) {
-                    parentParams = $lastViewScope.$eval(ref.paramExpr);
-                }
+                conf.ncyBreadcrumbGetLink = function() {
+                    var parentParams;
+                    if(ref.paramExpr) {
+                        parentParams = $lastViewScope.$eval(ref.paramExpr);
+                    }
+                    
+                    return $state.href(ref.state, parentParams || $stateParams || {});
+                };
 
-                conf.ncyBreadcrumbLink = $state.href(ref.state, parentParams || $stateParams || {});
+                conf.ncyBreadcrumbLink = conf.ncyBreadcrumbGetLink();
                 chain.unshift(conf);
             }
         };


### PR DESCRIPTION
add ncyBreadcrumbGetLink function to step object so that if your parent state params are not available right when the page loads, you can still have them available when the page is done loading