### PR TITLE
Add ability to cut the parents chain off

### DIFF
--- a/src/angular-breadcrumb.js
+++ b/src/angular-breadcrumb.js
@@ -88,7 +88,7 @@ function $Breadcrumb() {
                 // Handle the "parent" property of the breadcrumb, override the parent/child relation of the state
                 var isFunction = typeof conf.ncyBreadcrumb.parent === 'function';
                 var parentStateRef = isFunction ? conf.ncyBreadcrumb.parent($lastViewScope) : conf.ncyBreadcrumb.parent;
-                if(parentStateRef) {
+                if(parentStateRef || parentStateRef === false) {
                     return parentStateRef;
                 }
             }

--- a/src/angular-breadcrumb.js
+++ b/src/angular-breadcrumb.js
@@ -84,7 +84,7 @@ function $Breadcrumb() {
             var ref = parseStateRef(stateRef),
                 conf = $state.get(ref.state);
 
-            if(conf.ncyBreadcrumb && conf.ncyBreadcrumb.parent) {
+            if(conf.ncyBreadcrumb && typeof conf.ncyBreadcrumb.parent !== 'undefined') {
                 // Handle the "parent" property of the breadcrumb, override the parent/child relation of the state
                 var isFunction = typeof conf.ncyBreadcrumb.parent === 'function';
                 var parentStateRef = isFunction ? conf.ncyBreadcrumb.parent($lastViewScope) : conf.ncyBreadcrumb.parent;


### PR DESCRIPTION
Sometimes it is needed to just break state chain at some point.
I think passing { parent: false; } is the most straightforward and intuitive way for doing this.