### PR TITLE
Make compatible with amd-named & commonjs bundlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./release/angular-breadcrumb.js');
+module.exports = 'ncy-angular-breadcrumb';

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "url": "https://github.com/ncuillery/angular-breadcrumb/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "release/angular-breadcrumb.js",
+  "main": "index.js",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
Small fix to allow AMD-named & CommonJS bundlers like Browserify, RequireJS, Webpack to roll up angular-breadcrumb. Currently, we have to shim angular-breadcrumb's module name at bundle time.